### PR TITLE
Cell based distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,13 @@
 .vscode/
 
 bin/
-scripts/
-obj/
-output/
+
+# Ignore temporary files
 temp/
+*.asv
 
 # Ignore intermediary files
-*.o
+obj/
 
 #Ignore output files
-*.csv
+output/

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 
 all: build
 
+run:
+	./bin/main
+
 build_and_run:
 	make && ./bin/main
 

--- a/main.cu
+++ b/main.cu
@@ -7,47 +7,57 @@
 #include <stdexcept>
 #include <vector>
 
-// Around 2 million particles.
-const auto N = 1 << 21;
+struct Dimension {
+    float width;
+    float height;
+};
 
 // Switch between random and grid distribution.
 const auto is_randomly_distributed = true;
 
 // Size of 2D space.
-const auto width = 2000.0f;
-const auto height = 4000.0f;
-const auto half_width = width / 2;
-const auto half_height = height / 2;
+const auto space = Dimension{ width:2000.0f, height:4000.0f };
 
-// Size of 2D density grid.
-const auto U = static_cast<int>(width / 20);
-const auto V = static_cast<int>(height / 20);
+// Size of cell grid.
+const auto U = static_cast<int>(10);
+const auto V = static_cast<int>(20);
+
+const auto cell = Dimension{ space.width / U, space.height / V };
+
+// Lattice node count, where each node is a cell corner.
+const auto node_count = int2{ (U + 1), (V + 1) };
+
+const int cell_particle_count = 1;
+
+// Total number of particles.
+const auto N = cell_particle_count * U * V;
 
 const auto random_seed = 1u;
 
 // Allocation size for 1D arrays.
-const auto position_size = N * sizeof(float);
-const auto density_size = U * V * sizeof(float);
+const auto positions_bytes = N * sizeof(float);
+const auto lattice_bytes = node_count.x * node_count.y * sizeof(float);
 
 __host__ __device__
 auto x_to_u(float x) {
-    return (x / width + 0.5f) * (U - 1);
+    // + 0.5 to shift from [-0.5, 0.5) to [0, 1).
+    return (x / space.width + 0.5f) * U;
 }
 
 __host__ __device__
 auto y_to_v(float y) {
-    return (y / height + 0.5f) * (V - 1);
+    // + 0.5 to shift from [-0.5, 0.5) to [0, 1).
+    return (y / space.height + 0.5f) * V;
 }
 
 __host__ __device__
-auto get_density_index(const int2 uv) {
-    return uv.y * U + uv.x;
+auto get_node_index(const int2 node) {
+    return node.x + node.y * node_count.x;
 }
 
-__global__
-void print_point(float *x, float *y) {
-  int i = blockIdx.x * blockDim.x + threadIdx.x;
-  printf("(%9.3f, %9.3f)\n", x[i], y[i]);
+__host__ __device__
+auto get_particle_index(const int i, const int u, const int v) {
+    return i + (u + v * U) * cell_particle_count;
 }
 
 __global__
@@ -59,37 +69,36 @@ void add_density_atomic(float *pos_x, float *pos_y, float *density) {
 
     const auto x = pos_x[index];
     const auto y = pos_y[index];
-    // Add 0.5 to move from [-0.5, 0.5) to [0, 1).
     const auto u = x_to_u(x);
     const auto v = y_to_v(y);
     //printf("(%9.3f, %9.3f) -> (%7.3f, %7.3f)\n", x, y, u, v);
 
     // Node coordinates.
-    const auto pos_bottom_left = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
-    const auto pos_bottom_right = int2{ static_cast<int>(ceil(u)), static_cast<int>(floor(v)) };
-    const auto pos_top_left = int2{ static_cast<int>(floor(u)), static_cast<int>(ceil(v)) };
-    const auto pos_top_right = int2{ static_cast<int>(ceil(u)), static_cast<int>(ceil(v)) };
+    const auto node_bottom_left  = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
+    const auto node_bottom_right = int2{ static_cast<int>( ceil(u)), static_cast<int>(floor(v)) };
+    const auto node_top_left     = int2{ static_cast<int>(floor(u)), static_cast<int>( ceil(v)) };
+    const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
 
     // Node weights. https://www.particleincell.com/2010/es-pic-method/
-    const auto pos_cell = float2{ u - pos_bottom_left.x, v - pos_bottom_left.y };
-    const auto weight_bottom_left  = (1 - pos_cell.x) * (1 - pos_cell.y);
-    const auto weight_bottom_right =      pos_cell.x  * (1 - pos_cell.y);
-    const auto weight_top_left     = (1 - pos_cell.x) *      pos_cell.y;
-    const auto weight_top_right    =      pos_cell.x  *      pos_cell.y;
+    const auto pos_relative_cell = float2{ u - node_bottom_left.x, v - node_bottom_left.y };
+    const auto weight_bottom_left  = (1 - pos_relative_cell.x) * (1 - pos_relative_cell.y);
+    const auto weight_bottom_right =      pos_relative_cell.x  * (1 - pos_relative_cell.y);
+    const auto weight_top_left     = (1 - pos_relative_cell.x) *      pos_relative_cell.y;
+    const auto weight_top_right    =      pos_relative_cell.x  *      pos_relative_cell.y;
 
     // Node indices
-    const auto index_bottom_left = get_density_index(pos_bottom_left);
-    const auto index_bottom_right = get_density_index(pos_bottom_right);
-    const auto index_top_left = get_density_index(pos_top_left);
-    const auto index_top_right = get_density_index(pos_top_right);
+    const auto index_bottom_left = get_node_index(node_bottom_left);
+    const auto index_bottom_right = get_node_index(node_bottom_right);
+    const auto index_top_left = get_node_index(node_top_left);
+    const auto index_top_right = get_node_index(node_top_right);
 
     atomicAdd(&density[index_bottom_left], weight_bottom_left);
     atomicAdd(&density[index_bottom_right], weight_bottom_right);
     atomicAdd(&density[index_top_left], weight_top_left);
     atomicAdd(&density[index_top_right], weight_top_right);
 
-    /* printf("\n(%d, %d), (%d, %d)\n", pos_top_left.x, pos_top_left.y, pos_top_right.x, pos_top_right.y);
-    printf("(%d, %d), (%d, %d)\n", pos_bottom_left.x, pos_bottom_left.y, pos_bottom_right.x, pos_bottom_right.y);
+    /* printf("\n(%d, %d), (%d, %d)\n", node_top_left.x, node_top_left.y, node_top_right.x, node_top_right.y);
+    printf("(%d, %d), (%d, %d)\n", node_bottom_left.x, node_bottom_left.y, node_bottom_right.x, node_bottom_right.y);
 
     printf("%d, %d\n", index_top_left, index_top_right);
     printf("%d, %d\n", index_bottom_left, index_bottom_right);
@@ -99,38 +108,39 @@ void add_density_atomic(float *pos_x, float *pos_y, float *density) {
 }
 
 void distribute_random(std::span<float> pos_x, std::span<float> pos_y) {
-    // Randomly distribute particles in 2D space.
+    // Randomly distribute particles in cells.
     auto random_engine = std::default_random_engine(random_seed);
-    auto uniform_distribution_x = std::uniform_real_distribution<float>(-half_width, half_width);
-    auto uniform_distribution_y = std::uniform_real_distribution<float>(-half_height, half_height);
-    for (size_t i = 0; i < N; ++i) {
-        pos_x[i] = uniform_distribution_x(random_engine);
-        pos_y[i] = uniform_distribution_y(random_engine);
+    auto distribution_x = std::uniform_real_distribution(
+        0.0f, cell.width
+    );
+    auto distribution_y = std::uniform_real_distribution(
+        0.0f, cell.height
+    );
+
+    for (int v = 0; v < V; ++v) {
+        for (int u = 0; u < U; ++u) {
+            for (int i = 0; i <  cell_particle_count; ++i) {
+                const auto particle_index = get_particle_index(i, u, v);
+                const auto x = u * cell.width + distribution_x(random_engine) - space.width / 2;
+                const auto y = v * cell.height + distribution_y(random_engine) - space.height / 2;
+                pos_x[particle_index] = x;
+                pos_y[particle_index] = y;
+            }
+        }
     }
 }
 
-void distribute_grid(std::span<float> pos_x, std::span<float> pos_y) {
-    // Has to be a power of two to easily factor N into rows and columns.
-    auto is_power_of_two = [](const unsigned long x) {
-        // https://stackoverflow.com/a/600306
-        return (x != 0) && ((x & (x - 1)) == 0);
-    };
-    if (!is_power_of_two(N)) {
-        throw std::runtime_error("N has to be a power of 2 for grid distribution.");
-    }
-
-    // Factor N so that rows * columns = N.
-    const auto power = static_cast<int>(log2(N));
-    const auto row_power = power / 2;
-    const auto column_power = power - row_power;
-    const auto rows = 1 << row_power;
-    const auto columns = 1 << column_power;
-    
-    // Iterate over all N = rows * columns particles.
-    for (size_t j = 0; j < rows; ++j) {
-        for (size_t i = 0; i < columns; ++i) {
-            pos_x[j * columns + i] = i * width / columns - half_width;
-            pos_y[j * columns + i] = j * height / rows - half_height;
+void distribute_cell_center(std::span<float> pos_x, std::span<float> pos_y) {
+    // Place all particles in the center of each cell.
+    for (int v = 0; v < V; ++v) {
+        for (int u = 0; u < U; ++u) {
+            for (int i = 0; i <  cell_particle_count; ++i) {
+                const auto particle_index = get_particle_index(i, u, v);
+                const auto x = (u + 0.5) * cell.width - space.width / 2;
+                const auto y = (v + 0.5) * cell.height - space.height / 2;
+                pos_x[particle_index] = x;
+                pos_y[particle_index] = y;
+            }
         }
     }
 }
@@ -138,9 +148,9 @@ void distribute_grid(std::span<float> pos_x, std::span<float> pos_y) {
 void store_density(std::filesystem::path filepath,
                    std::span<const float> density) {
     auto density_file = std::ofstream(filepath);
-    for (int row = 0; row < V; ++row) {
-        for (int col = 0; col < U; ++col) {
-            density_file << density[row * U + col] << ',';
+    for (int row = 0; row < node_count.y; ++row) {
+        for (int col = 0; col < node_count.x; ++col) {
+            density_file << density[row * node_count.x + col] << ',';
         }
         density_file << '\n';
     }
@@ -157,34 +167,34 @@ void store_positions(std::filesystem::path filepath,
 
 int main() {
     // Allocate particle positions and densities on the host.
-    auto h_pos_x = std::vector<float>(position_size);
-    auto h_pos_y = std::vector<float>(position_size);
-    auto h_density = std::vector<float>(density_size);
+    auto h_pos_x = std::vector<float>(positions_bytes);
+    auto h_pos_y = std::vector<float>(positions_bytes);
+    auto h_density = std::vector<float>(lattice_bytes);
 
     // Allocate particle positions and densities on the device.
     float *d_pos_x;
     float *d_pos_y;
     float *d_density;
-    cudaMalloc(&d_pos_x, position_size);
-    cudaMalloc(&d_pos_y, position_size);
-    cudaMalloc(&d_density, density_size);
+    cudaMalloc(&d_pos_x, positions_bytes);
+    cudaMalloc(&d_pos_y, positions_bytes);
+    cudaMalloc(&d_density, lattice_bytes);
 
     if (is_randomly_distributed) {
         distribute_random(h_pos_x, h_pos_y);
     } else {
-        distribute_grid(h_pos_x, h_pos_y);
+        distribute_cell_center(h_pos_x, h_pos_y);
     }
 
     // Copy positions from the host to the device.
-    cudaMemcpy(d_pos_x, h_pos_x.data(), position_size, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_pos_y, h_pos_y.data(), position_size, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_pos_x, h_pos_x.data(), positions_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(d_pos_y, h_pos_y.data(), positions_bytes, cudaMemcpyHostToDevice);
 
     // Compute the particle density.
     const int block_size = 256;
     const int block_count = (N + block_size - 1) / block_size;
     add_density_atomic<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
     cudaDeviceSynchronize();
-    cudaMemcpy(h_density.data(), d_density, density_size, cudaMemcpyDeviceToHost);
+    cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
 
     // Store data to files.
     const auto output_directory = std::filesystem::path("output");

--- a/scripts/draw_data.m
+++ b/scripts/draw_data.m
@@ -1,0 +1,80 @@
+clear
+clc
+
+global left
+global right
+global top
+global bottom
+global cell_width
+global cell_height
+
+left = -1000;
+right = 1000;
+top = 2000;
+bottom = -2000;
+cell_width = 200;
+cell_height = 200;
+
+density = load("../output/density.csv");
+positions = load("../output/positions.csv");
+
+fig_1 = figure(1);
+clf
+hold on
+
+%draw_density(density);
+draw_grid(density);
+scatter(positions(:,1), positions(:,2), 150, '.b')
+hold off
+axis padded
+
+figure(2)
+clf
+%heatmap(0:size(density,2)-1, size(density,1)-1:-1:0, flipud(density))
+%grid off
+hold on
+draw_density(density);
+draw_grid(density);
+hold off
+
+function draw_density(density)
+global left
+global bottom
+global cell_width
+global cell_height
+
+max_density = max(density, [], 'All');
+
+scale = 1;
+
+for row = 0:size(density,1)-1
+    for column = 0:size(density,2)-1
+        x = left + (column - 0.5 * scale) * cell_width;
+        y = bottom + (row - 0.5 * scale) * cell_height;
+        color = density(row+1, column+1) / max_density;
+        rectangle('Position', [x, y, cell_width*scale, cell_height*scale], 'FaceColor',[1-color, 1-color, 1], 'LineStyle', 'none');
+    end
+end
+
+end
+
+function draw_grid(density)
+global left
+global right
+global top
+global bottom
+global cell_width
+global cell_height
+
+for i = 0:size(density,1)-1
+    y = bottom + i * cell_height;
+    plot([left, right], [y, y], 'k')
+end
+plot([left, right], [top, top], 'k')
+
+for i = 0:size(density,2)-1
+    x = left + i * cell_width;
+    plot([x, x], [bottom, top], 'k')
+end
+plot([right, right], [bottom, top], 'k')
+end


### PR DESCRIPTION
Instead of positioning the particles randomly over the whole space we instead do the same but on a cell-by-cell basis. This gives control over the number of particles per cell. This closes #1.

A Matlab script to plot the particle positions and cell corner densities is also included.

# Figures
These examples were generated with only one particle per cell.
## Particles
Particle positions are shown in blue against the black cell grid.
![particles](https://github.com/Gnaag98/cuda-summer-project/assets/21337929/d3cfd392-20f7-4b9b-8c57-82ac590b63ee)

## Density
Density is shown for each cell corner as a normalized heatmap.
![density](https://github.com/Gnaag98/cuda-summer-project/assets/21337929/b595124b-8429-4a95-9649-6b870279fe5d)
