### PR TITLE
Add dummy calculations

### DIFF
--- a/main.cu
+++ b/main.cu
@@ -8,6 +8,22 @@
 #include <vector>
 
 template<typename T>
+struct Vec3 {
+    T x;
+    T y;
+    T z;
+
+    __host__ __device__
+    constexpr static Vec3 cross(const Vec3 &a, const Vec3 &b) {
+        return Vec3{
+            a.y * b.z - a.z * b.y,
+            a.z * b.x - a.x * b.z,
+            a.x * b.y - a.y * b.x
+        };
+    }
+};
+
+template<typename T>
 struct Dimension {
     T width;
     T height;
@@ -44,11 +60,11 @@ struct Rectangle {
 const auto is_randomly_distributed = true;
 
 // Size of 2D space.
-const auto space = Rectangle<float>::centered(2000.0f, 4000.0f);
+const auto space = Rectangle<float>::centered(2048.0f, 4096.0f);
 
 // Number of cells in the grid.
-const auto U = static_cast<int>(10);
-const auto V = static_cast<int>(20);
+const auto U = static_cast<int>(128);
+const auto V = static_cast<int>(256);
 
 const auto cell = Dimension{
     .width = space.width / U,
@@ -58,7 +74,7 @@ const auto cell = Dimension{
 // Lattice node count, where each node is a cell corner.
 const auto node_count = int2{ (U + 1), (V + 1) };
 
-const int cell_particle_count = 1;
+const int cell_particle_count = 1024;
 
 // Total number of particles.
 const auto N = cell_particle_count * U * V;
@@ -104,7 +120,7 @@ auto get_particle_index(const int i, const int u, const int v) {
 }
 
 __global__
-void add_density_atomic(float *pos_x, float *pos_y, float *density) {
+void add_density_atomic(float *const pos_x, float *const pos_y, float *density) {
     const auto index = blockIdx.x * blockDim.x + threadIdx.x;
     if (index >= N) {
         return;
@@ -139,15 +155,101 @@ void add_density_atomic(float *pos_x, float *pos_y, float *density) {
     atomicAdd(&density[index_bottom_right], weight_bottom_right);
     atomicAdd(&density[index_top_left], weight_top_left);
     atomicAdd(&density[index_top_right], weight_top_right);
+}
 
-    /* printf("\n(%d, %d), (%d, %d)\n", node_top_left.x, node_top_left.y, node_top_right.x, node_top_right.y);
-    printf("(%d, %d), (%d, %d)\n", node_bottom_left.x, node_bottom_left.y, node_bottom_right.x, node_bottom_right.y);
+__global__
+void add_density_dummy(float *const pos_x, float *const pos_y) {
+    const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= N) {
+        return;
+    }
 
-    printf("%d, %d\n", index_top_left, index_top_right);
-    printf("%d, %d\n", index_bottom_left, index_bottom_right);
+    const auto x = pos_x[index];
+    const auto y = pos_y[index];
+    const auto u = x_to_u(x);
+    const auto v = y_to_v(y);
+    //printf("(%9.3f, %9.3f) -> (%7.3f, %7.3f)\n", x, y, u, v);
 
-    printf("%7.3f, %7.3f\n", weight_top_left, weight_top_right);
-    printf("%7.3f, %7.3f\n\n", weight_bottom_left, weight_bottom_right); */
+    // Node coordinates.
+    const auto node_bottom_left  = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
+    const auto node_bottom_right = int2{ static_cast<int>( ceil(u)), static_cast<int>(floor(v)) };
+    const auto node_top_left     = int2{ static_cast<int>(floor(u)), static_cast<int>( ceil(v)) };
+    const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
+
+    // Node weights. https://www.particleincell.com/2010/es-pic-method/
+    const auto pos_relative_cell = float2{ u - node_bottom_left.x, v - node_bottom_left.y };
+    const auto weight_bottom_left  = (1 - pos_relative_cell.x) * (1 - pos_relative_cell.y);
+    const auto weight_bottom_right =      pos_relative_cell.x  * (1 - pos_relative_cell.y);
+    const auto weight_top_left     = (1 - pos_relative_cell.x) *      pos_relative_cell.y;
+    const auto weight_top_right    =      pos_relative_cell.x  *      pos_relative_cell.y;
+
+    // Node indices.
+    const auto index_bottom_left = get_node_index(node_bottom_left);
+    const auto index_bottom_right = get_node_index(node_bottom_right);
+    const auto index_top_left = get_node_index(node_top_left);
+    const auto index_top_right = get_node_index(node_top_right);
+
+    auto dummy_sum = 0.0f;
+    dummy_sum += weight_bottom_left;
+    dummy_sum += weight_bottom_right;
+    dummy_sum += weight_top_left;
+    dummy_sum += weight_top_right;
+}
+
+__global__
+void calculate_gradient(float *const pos_x, float *const pos_y, float *const density) {
+    const auto index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= N) {
+        return;
+    }
+
+    auto lerp = [](const float a, const float b, const float t) {
+        return a + (b - a) * t;
+    };
+
+    const auto x = pos_x[index];
+    const auto y = pos_y[index];
+    const auto u = x_to_u(x);
+    const auto v = y_to_v(y);
+
+    // Node coordinates.
+    const auto node_bottom_left  = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
+    const auto node_bottom_right = int2{ static_cast<int>( ceil(u)), static_cast<int>(floor(v)) };
+    const auto node_top_left     = int2{ static_cast<int>(floor(u)), static_cast<int>( ceil(v)) };
+    const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
+
+    // Node indices.
+    const auto index_bottom_left = get_node_index(node_bottom_left);
+    const auto index_bottom_right = get_node_index(node_bottom_right);
+    const auto index_top_left = get_node_index(node_top_left);
+    const auto index_top_right = get_node_index(node_top_right);
+
+    const auto density_bottom_left = density[index_bottom_left];
+    const auto density_bottom_right = density[index_bottom_right];
+    const auto density_top_left = density[index_top_left];
+    const auto density_top_right = density[index_top_right];
+
+    const auto pos_relative_cell = float2{ u - node_bottom_left.x, v - node_bottom_left.y };
+
+    const auto density_bottom = lerp(density_bottom_left, density_bottom_right, pos_relative_cell.x);
+    const auto density_top = lerp(density_top_left, density_top_right, pos_relative_cell.x);
+    [[maybe_unused]] const auto slope_y = (density_top - density_bottom) / space.height;
+
+    const auto density_left = lerp(density_bottom_left, density_top_left, pos_relative_cell.y);
+    const auto density_right = lerp(density_bottom_right, density_top_right, pos_relative_cell.y);
+    [[maybe_unused]] const auto slope_x = (density_right - density_left) / space.width;
+
+    const auto tangent_x = Vec3<float>{
+        .x = space.width,
+        .y = 0,
+        .z = density_right - density_left
+    };
+    const auto tangent_y = Vec3<float>{
+        .x = 0,
+        .y = space.height,
+        .z = density_top - density_bottom
+    };
+    const auto normal = Vec3<float>::cross(tangent_x, tangent_y);
 }
 
 void distribute_random(std::span<float> pos_x, std::span<float> pos_y) {
@@ -235,9 +337,19 @@ int main() {
     // Compute the particle density.
     const int block_size = 256;
     const int block_count = (N + block_size - 1) / block_size;
-    add_density_atomic<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
-    cudaDeviceSynchronize();
-    cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
+
+    // Loop for better statistics.
+    for (int i = 0; i < 100; ++i) {
+        add_density_atomic<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
+        cudaDeviceSynchronize();
+        cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
+
+        // Dummy calculations.
+        add_density_dummy<<<block_count, block_size>>>(d_pos_x, d_pos_y);
+        cudaDeviceSynchronize();
+        calculate_gradient<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
+        cudaDeviceSynchronize();
+    }
 
     // Store data to files.
     const auto output_directory = std::filesystem::path("output");


### PR DESCRIPTION
There are now two kernels that run along side the atomic add one, to give context to the time output of the profiler. This closes #2.

The kernels are also run 100 times to get better statistics.

## Profiler output
This is the output of a run on an RTX 2080 with ~33 million particles. The dummy functions are ```calculate_gradient``` and ```add_density_dummy```, and we can clearly see that the atomic instructions are the bottleneck.
```
==178773== Profiling result:
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   74.60%  7.34807s       100  73.481ms  72.870ms  92.814ms  add_density_atomic(float*, float*, float*)
                   15.76%  1.55227s       100  15.523ms  15.439ms  16.203ms  calculate_gradient(float*, float*, float*)
                    9.18%  904.30ms       100  9.0430ms  8.9349ms  10.129ms  add_density_dummy(float*, float*)
                    0.45%  44.520ms         2  22.260ms  22.008ms  22.513ms  [CUDA memcpy HtoD]
                    0.01%  1.0803ms       100  10.802us  10.719us  11.392us  [CUDA memcpy DtoH]
      API calls:   97.86%  9.80532s       300  32.684ms  8.9366ms  92.813ms  cudaDeviceSynchronize
                    1.28%  128.27ms         3  42.756ms  44.609us  128.15ms  cudaMalloc
                    0.49%  48.604ms       102  476.51us  34.793us  22.619ms  cudaMemcpy
                    0.31%  30.787ms       300  102.62us  2.8430us  29.020ms  cudaLaunchKernel
                    0.04%  3.9826ms       114  34.934us      68ns  2.3367ms  cuDeviceGetAttribute
                    0.03%  2.5262ms         2  1.2631ms  351.85us  2.1744ms  cudaFree
                    0.00%  8.3360us         1  8.3360us  8.3360us  8.3360us  cuDeviceGetName
                    0.00%  4.6280us         1  4.6280us  4.6280us  4.6280us  cuDeviceGetPCIBusId
                    0.00%     696ns         3     232ns      96ns     482ns  cuDeviceGetCount
                    0.00%     351ns         2     175ns      83ns     268ns  cuDeviceGet
                    0.00%     290ns         1     290ns     290ns     290ns  cuModuleGetLoadingMode
                    0.00%     281ns         1     281ns     281ns     281ns  cuDeviceTotalMem
                    0.00%     210ns         1     210ns     210ns     210ns  cuDeviceGetUuid
```