### PR TITLE
Fix discrepancies between methods

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -48,7 +48,7 @@ const auto cell = Dimension{
 // Lattice node count, where each node is a cell corner.
 const auto node_count = Dimension{ (U + 1), (V + 1) };
 
-const int cell_particle_count = 256;
+const auto cell_particle_count = 256;
 
 // Total number of particles.
 const auto N = cell_particle_count * U * V;
@@ -61,7 +61,7 @@ const auto lattice_count = (U + 1) * (V + 1);
 const auto positions_bytes = positions_count * sizeof(float);
 const auto lattice_bytes = lattice_count * sizeof(float);
 
-const auto block_size = 256;
+const auto block_size = cell_particle_count;
 const auto block_count = (N + block_size - 1) / block_size;
 
 template<typename T>

--- a/main_shared.cu
+++ b/main_shared.cu
@@ -15,38 +15,25 @@ __global__ void add_density_shared(const float *pos_x, const float *pos_y,
 
     const auto index = threadIdx.x;
 
+    // XXX: Assumes one block per cell.
+    const auto cell_origin = uint2{ blockIdx.x % U, blockIdx.x / U };
+    // Node indices.
+    const auto index_bottom_left = get_node_index(cell_origin.x, cell_origin.y);
+    const auto index_bottom_right = get_node_index(cell_origin.x +1, cell_origin.y);
+    const auto index_top_left = get_node_index(cell_origin.x, cell_origin.y + 1);
+    const auto index_top_right = get_node_index(cell_origin.x + 1, cell_origin.y + 1);
+
     const auto x = pos_x[particle_index];
     const auto y = pos_y[particle_index];
     const auto u = x_to_u(x);
     const auto v = y_to_v(y);
 
-
-    // Node coordinates.
-    const auto node_bottom_left  = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
-    const auto node_bottom_right = int2{ static_cast<int>( ceil(u)), static_cast<int>(floor(v)) };
-    const auto node_top_left     = int2{ static_cast<int>(floor(u)), static_cast<int>( ceil(v)) };
-    const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
-
     // Node weights. https://www.particleincell.com/2010/es-pic-method/
-    // NOTE: Error-prone calculation of cell origin. If point on border this
-    // could result in the origin of a neighboring cell.
-    //const auto cell_origin = float2{ node_bottom_left.x, node_bottom_left.y };
-
-    // Better calculation of cell origin based on block id.
-    // XXX: Assumes one block per cell.
-    const auto cell_origin = uint2{ blockIdx.x % U, blockIdx.x / U };
-    
     const auto pos_relative_cell = float2{ u - cell_origin.x, v - cell_origin.y };
     const auto weight_bottom_left  = (1 - pos_relative_cell.x) * (1 - pos_relative_cell.y);
     const auto weight_bottom_right =      pos_relative_cell.x  * (1 - pos_relative_cell.y);
     const auto weight_top_left     = (1 - pos_relative_cell.x) *      pos_relative_cell.y;
     const auto weight_top_right    =      pos_relative_cell.x  *      pos_relative_cell.y;
-
-    // Node indices.
-    const auto index_bottom_left = get_node_index(node_bottom_left.x, node_bottom_left.y);
-    const auto index_bottom_right = get_node_index(node_bottom_right.x, node_bottom_right.y);
-    const auto index_top_left = get_node_index(node_top_left.x, node_top_left.y);
-    const auto index_top_right = get_node_index(node_top_right.x, node_top_right.y);
 
     // Each particle will contribute to 4 cells.
     __shared__ float density_shared[4][block_size];
@@ -68,68 +55,12 @@ __global__ void add_density_shared(const float *pos_x, const float *pos_y,
         __syncthreads();
     }
 
-    if (threadIdx.x == 0) {
+    if (index == 0) {
         atomicAdd(&density[index_bottom_left], density_shared[0][0]);
         atomicAdd(&density[index_bottom_right], density_shared[1][0]);
         atomicAdd(&density[index_top_left], density_shared[2][0]);
         atomicAdd(&density[index_top_right], density_shared[3][0]);
     }
-}
-
-__global__ void add_density_debug(const float *pos_x, const float *pos_y,
-        float *density, float *density_shared) {
-    const auto particle_index = blockIdx.x * blockDim.x + threadIdx.x;
-    if (particle_index >= N) {
-        return;
-    }
-
-    const auto x = pos_x[particle_index];
-    const auto y = pos_y[particle_index];
-    const auto u = x_to_u(x);
-    const auto v = y_to_v(y);
-
-    // Node coordinates.
-    const auto node_bottom_left  = int2{ static_cast<int>(floor(u)), static_cast<int>(floor(v)) };
-    const auto node_bottom_right = int2{ static_cast<int>( ceil(u)), static_cast<int>(floor(v)) };
-    const auto node_top_left     = int2{ static_cast<int>(floor(u)), static_cast<int>( ceil(v)) };
-    const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
-
-    // Node weights. https://www.particleincell.com/2010/es-pic-method/
-    const auto pos_relative_cell = float2{ u - node_bottom_left.x, v - node_bottom_left.y };
-    const auto weight_bottom_left  = (1 - pos_relative_cell.x) * (1 - pos_relative_cell.y);
-    const auto weight_bottom_right =      pos_relative_cell.x  * (1 - pos_relative_cell.y);
-    const auto weight_top_left     = (1 - pos_relative_cell.x) *      pos_relative_cell.y;
-    const auto weight_top_right    =      pos_relative_cell.x  *      pos_relative_cell.y;
-
-    // Node indices.
-    const auto index_bottom_left = get_node_index(node_bottom_left.x, node_bottom_left.y);
-    const auto index_bottom_right = get_node_index(node_bottom_right.x, node_bottom_right.y);
-    const auto index_top_left = get_node_index(node_top_left.x, node_top_left.y);
-    const auto index_top_right = get_node_index(node_top_right.x, node_top_right.y);
-
-    density_shared[particle_index + 0 * N] = weight_bottom_left;
-    density_shared[particle_index + 1 * N] = weight_bottom_right;
-    density_shared[particle_index + 2 * N] = weight_top_left;
-    density_shared[particle_index + 3 * N] = weight_top_right;
-    /* __syncthreads();
-
-    // in-place reduction in global memory
-    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (index < stride) {
-            density_shared[particle_index + 0 * N] += density_shared[particle_index + stride + 0 * N];
-            density_shared[particle_index + 1 * N] += density_shared[particle_index + stride + 1 * N];
-            density_shared[particle_index + 2 * N] += density_shared[particle_index + stride + 2 * N];
-            density_shared[particle_index + 3 * N] += density_shared[particle_index + stride + 3 * N];
-        }
-        __syncthreads();
-    }
-
-    if (true) {
-        atomicAdd(&density[index_bottom_left], 0);
-        atomicAdd(&density[index_bottom_right], 0);
-        atomicAdd(&density[index_top_left], 0);
-        atomicAdd(&density[index_top_right], 0);
-    } */
 }
 
 void store_density(std::filesystem::path filepath,

--- a/scripts/draw_diff.m
+++ b/scripts/draw_diff.m
@@ -5,14 +5,14 @@ tolerance = 0.1;
 
 density_atomic = load("../output/density_atomic.csv");
 density_shared = load("../output/density_shared.csv");
-density_diff = density_atomic - density_shared;
+density_diff = density_shared - density_atomic;
 density_error = double(density_diff > tolerance) - double(density_diff < -tolerance);
 
 figure(1)
 clf
 heatmap(0:size(density_atomic,2)-1, size(density_atomic,1)-1:-1:0, flipud(density_atomic))
 grid off
-title('shared')
+title('atomic')
 
 figure(2)
 clf


### PR DESCRIPTION
The issue how the node indices were calculated. Now they are calculated from the cell origin instead of the particle position. This means that particles on cell borders will be handled correctly. This fixes #9.

## Comparison heat map
The below figure shows the difference in produces densities of the two methods. The values now differ by 10<sup>-3</sup>, which is surprisingly high since the methods should only differ how additions are performed.

![diff_heat_map](https://github.com/user-attachments/assets/65be8e66-aca2-4700-8be7-d2d20084b8ab)
