### PR TITLE
Add option to swith floating point type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-flags = -std=c++20 --expt-relaxed-constexpr
+flags = -std=c++20 -arch=sm_60 --expt-relaxed-constexpr
 
 all: build
 

--- a/common.hpp
+++ b/common.hpp
@@ -3,6 +3,17 @@
 
 #include <random>
 #include <span>
+#include <type_traits>
+
+// Select float or double for all floating point types.
+using FloatingPoint = float;
+
+using FloatingPoint2 = std::conditional<
+    std::is_same<FloatingPoint, float>::value, float2, double2
+>::type;
+using FloatingPoint3 = std::conditional<
+    std::is_same<FloatingPoint, float>::value, float3, double3
+>::type;
 
 template<typename T>
 struct Dimension {
@@ -34,7 +45,7 @@ struct Rectangle {
 };
 
 // Size of 2D space.
-const auto space = Rectangle<float>::centered(2048.0f, 4096.0f);
+const auto space = Rectangle<FloatingPoint>::centered(2048.0, 4096.0);
 
 // Number of cells in the grid.
 const auto U = static_cast<int>(128);
@@ -58,8 +69,8 @@ const auto random_seed = 1u;
 // Allocation size for 1D arrays.
 const auto positions_count = N;
 const auto lattice_count = (U + 1) * (V + 1);
-const auto positions_bytes = positions_count * sizeof(float);
-const auto lattice_bytes = lattice_count * sizeof(float);
+const auto positions_bytes = positions_count * sizeof(FloatingPoint);
+const auto lattice_bytes = lattice_count * sizeof(FloatingPoint);
 
 const auto block_size = cell_particle_count;
 const auto block_count = (N + block_size - 1) / block_size;
@@ -74,15 +85,15 @@ constexpr auto linear_map(const T x, const T x1, const T x2, const T y1, const T
 /**
  * Convert world x coordinate to horizontal cell index.
  */
-constexpr auto x_to_u(float x) {
-    return linear_map<float>(x, space.left(), space.right(), 0, U);
+constexpr auto x_to_u(FloatingPoint x) {
+    return linear_map<FloatingPoint>(x, space.left(), space.right(), 0, U);
 }
 
 /**
  * Convert world y coordinate to vertical cell index.
  */
-constexpr auto y_to_v(float y) {
-    return linear_map<float>(y, space.bottom(), space.top(), 0, V);
+constexpr auto y_to_v(FloatingPoint y) {
+    return linear_map<FloatingPoint>(y, space.bottom(), space.top(), 0, V);
 }
 
 constexpr auto get_node_index(const int x, const int y) {
@@ -93,14 +104,14 @@ constexpr auto get_particle_index(const int i, const int u, const int v) {
     return i + (u + v * U) * cell_particle_count;
 }
 
-void distribute_random(std::span<float> pos_x, std::span<float> pos_y) {
+void distribute_random(std::span<FloatingPoint> pos_x, std::span<FloatingPoint> pos_y) {
     // Randomly distribute particles in cells.
     auto random_engine = std::default_random_engine(random_seed);
-    auto distribution_x = std::uniform_real_distribution(
-        0.0f, cell.width
+    auto distribution_x = std::uniform_real_distribution<FloatingPoint>(
+        0.0, cell.width
     );
-    auto distribution_y = std::uniform_real_distribution(
-        0.0f, cell.height
+    auto distribution_y = std::uniform_real_distribution<FloatingPoint>(
+        0.0, cell.height
     );
 
     for (int v = 0; v < V; ++v) {
@@ -116,7 +127,7 @@ void distribute_random(std::span<float> pos_x, std::span<float> pos_y) {
     }
 }
 
-void distribute_cell_center(std::span<float> pos_x, std::span<float> pos_y) {
+void distribute_cell_center(std::span<FloatingPoint> pos_x, std::span<FloatingPoint> pos_y) {
     // Place all particles in the center of each cell.
     for (int v = 0; v < V; ++v) {
         for (int u = 0; u < U; ++u) {

--- a/main_atomic.cu
+++ b/main_atomic.cu
@@ -6,8 +6,8 @@
 #include "common.hpp"
 
 __global__
-void add_density_atomic(const float *pos_x, const float *pos_y,
-        float *density) {
+void add_density_atomic(const FloatingPoint *pos_x, const FloatingPoint *pos_y,
+        FloatingPoint *density) {
     const auto index = blockIdx.x * blockDim.x + threadIdx.x;
     if (index >= N) {
         return;
@@ -25,7 +25,7 @@ void add_density_atomic(const float *pos_x, const float *pos_y,
     const auto node_top_right    = int2{ static_cast<int>( ceil(u)), static_cast<int>( ceil(v)) };
 
     // Node weights. https://www.particleincell.com/2010/es-pic-method/
-    const auto pos_relative_cell = float2{ u - node_bottom_left.x, v - node_bottom_left.y };
+    const auto pos_relative_cell = FloatingPoint2{ u - node_bottom_left.x, v - node_bottom_left.y };
     const auto weight_bottom_left  = (1 - pos_relative_cell.x) * (1 - pos_relative_cell.y);
     const auto weight_bottom_right =      pos_relative_cell.x  * (1 - pos_relative_cell.y);
     const auto weight_top_left     = (1 - pos_relative_cell.x) *      pos_relative_cell.y;
@@ -44,7 +44,7 @@ void add_density_atomic(const float *pos_x, const float *pos_y,
 }
 
 void store_density(std::filesystem::path filepath,
-                   std::span<const float> density) {
+                   std::span<const FloatingPoint> density) {
     auto density_file = std::ofstream(filepath);
     for (int row = 0; row < (V + 1); ++row) {
         for (int col = 0; col < (U + 1); ++col) {
@@ -56,14 +56,14 @@ void store_density(std::filesystem::path filepath,
 
 int main() {
     // Allocate particle positions and densities on the host.
-    auto h_pos_x = std::vector<float>(positions_count);
-    auto h_pos_y = std::vector<float>(positions_count);
-    auto h_density = std::vector<float>(lattice_count);
+    auto h_pos_x = std::vector<FloatingPoint>(positions_count);
+    auto h_pos_y = std::vector<FloatingPoint>(positions_count);
+    auto h_density = std::vector<FloatingPoint>(lattice_count);
 
     // Allocate particle positions and densities on the device.
-    float *d_pos_x;
-    float *d_pos_y;
-    float *d_density;
+    FloatingPoint *d_pos_x;
+    FloatingPoint *d_pos_y;
+    FloatingPoint *d_density;
     cudaMalloc(&d_pos_x, positions_bytes);
     cudaMalloc(&d_pos_y, positions_bytes);
     cudaMalloc(&d_density, lattice_bytes);


### PR DESCRIPTION
There is now the type alias "FloatingPoint" that can be chosen as wither float or double. This replaces all references to "float" in the code. This closes #13.

To have atomicAdd for doubles, the minimum compute capability is now 6.0.

## Comparison of float and double
When computing the densities using doubles instead of floats, the errors between the methods disappeared. That means the error referred to in #12 is due to single-precision rounding errors. That answer is good enough and therefore close #12.