### PR TITLE
Less restrictive shared memory kernel

### DIFF
--- a/common.hpp
+++ b/common.hpp
@@ -59,7 +59,7 @@ const auto cell = Dimension{
 // Lattice node count, where each node is a cell corner.
 const auto node_count = Dimension{ (U + 1), (V + 1) };
 
-const auto cell_particle_count = 256;
+const auto cell_particle_count = 1024 + 87;
 
 // Total number of particles.
 const auto N = cell_particle_count * U * V;
@@ -72,8 +72,9 @@ const auto lattice_count = (U + 1) * (V + 1);
 const auto positions_bytes = positions_count * sizeof(FloatingPoint);
 const auto lattice_bytes = lattice_count * sizeof(FloatingPoint);
 
-const auto block_size = cell_particle_count;
-const auto block_count = (N + block_size - 1) / block_size;
+const auto block_size = 256;
+const auto blocks_per_cell = (cell_particle_count + block_size - 1) / block_size;
+const auto block_count = U * V * blocks_per_cell;
 
 template<typename T>
 constexpr auto linear_map(const T x, const T x1, const T x2, const T y1, const T y2) {

--- a/common.hpp
+++ b/common.hpp
@@ -59,7 +59,7 @@ const auto cell = Dimension{
 // Lattice node count, where each node is a cell corner.
 const auto node_count = Dimension{ (U + 1), (V + 1) };
 
-const auto cell_particle_count = 1024 + 87;
+const auto cell_particle_count = 1024;
 
 // Total number of particles.
 const auto N = cell_particle_count * U * V;
@@ -72,7 +72,7 @@ const auto lattice_count = (U + 1) * (V + 1);
 const auto positions_bytes = positions_count * sizeof(FloatingPoint);
 const auto lattice_bytes = lattice_count * sizeof(FloatingPoint);
 
-const auto block_size = 256;
+const auto block_size = 128;
 const auto blocks_per_cell = (cell_particle_count + block_size - 1) / block_size;
 const auto block_count = U * V * blocks_per_cell;
 

--- a/main_atomic.cu
+++ b/main_atomic.cu
@@ -74,8 +74,10 @@ int main() {
     cudaMemcpy(d_pos_x, h_pos_x.data(), positions_bytes, cudaMemcpyHostToDevice);
     cudaMemcpy(d_pos_y, h_pos_y.data(), positions_bytes, cudaMemcpyHostToDevice);
 
+    // Initialize density.
+    cudaMemset(d_density, 0, lattice_bytes);
+
     add_density_atomic<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
-    cudaDeviceSynchronize();
     cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
 
     // Free device memory.

--- a/main_shared.cu
+++ b/main_shared.cu
@@ -99,10 +99,6 @@ int main() {
     cudaMalloc(&d_pos_y, positions_bytes);
     cudaMalloc(&d_density, lattice_bytes);
 
-    auto h_shared = std::vector<FloatingPoint>(4 * N);
-    FloatingPoint *d_shared;
-    cudaMalloc(&d_shared, 4 * N * sizeof(FloatingPoint));
-
     distribute_random(h_pos_x, h_pos_y);
 
     // Copy positions from the host to the device.
@@ -117,17 +113,12 @@ int main() {
     //cudaDeviceSynchronize();
     cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
 
-    cudaMemcpy(h_shared.data(), d_shared, 4 * N * sizeof(FloatingPoint), cudaMemcpyDeviceToHost);
-
     // Free device memory.
     cudaFree(d_pos_x);
     cudaFree(d_pos_y);
-
-    cudaFree(d_shared);
 
     // Store data to files.
     const auto output_directory = std::filesystem::path("output");
     std::filesystem::create_directory(output_directory);
     store_density(output_directory / "density_shared.csv", h_density);
-    store_debug(output_directory / "debug_shared.csv", h_shared);
 }

--- a/main_shared.cu
+++ b/main_shared.cu
@@ -123,8 +123,6 @@ int main() {
     cudaMemset(d_density, 0, lattice_bytes);
 
     add_density_shared<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density);
-    //add_density_debug<<<block_count, block_size>>>(d_pos_x, d_pos_y, d_density, d_shared);
-    //cudaDeviceSynchronize();
     cudaMemcpy(h_density.data(), d_density, lattice_bytes, cudaMemcpyDeviceToHost);
 
     // Free device memory.


### PR DESCRIPTION
Now the shared version can compute the correct result no matter how many particles per cell, both larger and smaller than the block size. This closes #10.